### PR TITLE
Add stage-specific concurrency and retry safeguards

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -33,3 +33,24 @@ OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 
 # Data directory for conversation storage
 DATA_DIR = "data/conversations"
+
+# Default stage limits (timeouts in seconds, concurrency counts)
+DEFAULT_STAGE_LIMITS = {
+    "stage1": {"timeout": 120.0, "concurrency": 6},
+    "stage2": {"timeout": 180.0, "concurrency": 4},
+}
+
+# Optional per-councilor overrides for stage behavior
+# Example:
+# COUNCILOR_STAGE_OVERRIDES = {
+#     "some/model": {
+#         "stage1_timeout": 90.0,
+#         "stage2_timeout": 150.0,
+#         "stage1_concurrency": 2,
+#         "stage2_concurrency": 3,
+#     }
+# }
+COUNCILOR_STAGE_OVERRIDES = {}
+
+# Backoff configuration for transient failures
+RATE_LIMIT_BACKOFF_SECONDS = 2

--- a/backend/council.py
+++ b/backend/council.py
@@ -6,6 +6,23 @@ import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from openrouter import query_models_parallel, query_model
+from config import DEFAULT_STAGE_LIMITS, COUNCILOR_STAGE_OVERRIDES
+
+
+def _get_stage_timeout(model: str, stage_key: str) -> float:
+    override = COUNCILOR_STAGE_OVERRIDES.get(model, {})
+    return override.get(f"{stage_key}_timeout", DEFAULT_STAGE_LIMITS[stage_key]["timeout"])
+
+
+def _get_stage_concurrency(models: List[str], stage_key: str) -> int:
+    override_values = [
+        COUNCILOR_STAGE_OVERRIDES.get(model, {}).get(f"{stage_key}_concurrency")
+        for model in models
+        if COUNCILOR_STAGE_OVERRIDES.get(model, {}).get(f"{stage_key}_concurrency") is not None
+    ]
+    if override_values:
+        return min(override_values)
+    return DEFAULT_STAGE_LIMITS[stage_key]["concurrency"]
 
 
 async def stage1_collect_responses(user_query: str, council_models: List[str]) -> List[Dict[str, Any]]:
@@ -28,7 +45,17 @@ async def stage1_collect_responses(user_query: str, council_models: List[str]) -
     ]
 
     # Query all models in parallel
-    responses = await query_models_parallel(council_models, messages)
+    concurrency = _get_stage_concurrency(council_models, "stage1")
+    timeouts = {
+        model: _get_stage_timeout(model, "stage1") for model in council_models
+    }
+    responses = await query_models_parallel(
+        council_models,
+        messages,
+        concurrency=concurrency,
+        default_timeout=DEFAULT_STAGE_LIMITS["stage1"]["timeout"],
+        timeout_overrides=timeouts,
+    )
 
     # Format results
     stage1_results = []
@@ -114,7 +141,17 @@ Now evaluate and rank the responses."""
     ]
 
     # Get rankings from all council models in parallel
-    responses = await query_models_parallel(council_models, messages)
+    concurrency = _get_stage_concurrency(council_models, "stage2")
+    timeouts = {
+        model: _get_stage_timeout(model, "stage2") for model in council_models
+    }
+    responses = await query_models_parallel(
+        council_models,
+        messages,
+        concurrency=concurrency,
+        default_timeout=DEFAULT_STAGE_LIMITS["stage2"]["timeout"],
+        timeout_overrides=timeouts,
+    )
 
     # Format results
     stage2_results = []

--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -1,18 +1,26 @@
 """OpenRouter API client for making LLM requests."""
 
+import asyncio
 import httpx
 from typing import List, Dict, Any, Optional
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from config import OPENROUTER_API_KEY, OPENROUTER_API_URL
+from config import (
+    OPENROUTER_API_KEY,
+    OPENROUTER_API_URL,
+    RATE_LIMIT_BACKOFF_SECONDS,
+)
 
 
 async def query_model(
     model: str,
     messages: List[Dict[str, str]],
-    timeout: float = 120.0
+    timeout: float = 120.0,
+    *,
+    max_json_retries: int = 1,
+    max_rate_limit_retries: int = 1,
 ) -> Optional[Dict[str, Any]]:
     """
     Query a single model via OpenRouter API.
@@ -35,38 +43,89 @@ async def query_model(
         "messages": messages,
     }
 
+    async def perform_request(current_messages: List[Dict[str, str]], retrying: bool) -> Optional[Dict[str, Any]]:
+        rate_attempts = 0
+        while True:
+            try:
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    response = await client.post(
+                        OPENROUTER_API_URL,
+                        headers=headers,
+                        json={"model": model, "messages": current_messages},
+                    )
+
+                if response.status_code == 429 and rate_attempts < max_rate_limit_retries:
+                    await asyncio.sleep(RATE_LIMIT_BACKOFF_SECONDS)
+                    rate_attempts += 1
+                    continue
+
+                response.raise_for_status()
+
+                try:
+                    data = response.json()
+                except ValueError:
+                    return None
+
+                message = data["choices"][0]["message"]
+                return {
+                    "content": message.get("content"),
+                    "reasoning_details": message.get("reasoning_details"),
+                    "model": data.get("model"),
+                }
+
+            except Exception as e:
+                print(f"Error querying model {model}: {e}")
+                if isinstance(e, httpx.HTTPStatusError):
+                    print(f"Response body: {e.response.text}")
+                if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 429:
+                    # Exhausted rate limit retries
+                    return {
+                        "content": f"Error: rate limited for model {model}",
+                        "error": True,
+                        "model": model,
+                    }
+
+                if retrying:
+                    # Only one retry cycle is allowed
+                    return {
+                        "content": f"Error: {str(e)}",
+                        "error": True,
+                        "model": model,
+                    }
+                raise
+
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(
-                OPENROUTER_API_URL,
-                headers=headers,
-                json=payload
-            )
-            response.raise_for_status()
+        data = await perform_request(messages, retrying=False)
 
-            data = response.json()
-            message = data['choices'][0]['message']
+        json_attempts = 0
+        while data is None and json_attempts < max_json_retries:
+            strict_messages = messages + [
+                {
+                    "role": "system",
+                    "content": "Return a valid JSON response following the chat completion schema only.",
+                }
+            ]
+            json_attempts += 1
+            data = await perform_request(strict_messages, retrying=True)
 
-            return {
-                'content': message.get('content'),
-                'reasoning_details': message.get('reasoning_details'),
-                'model': data.get('model')  # Capture actual model used
-            }
+        return data
 
     except Exception as e:
         print(f"Error querying model {model}: {e}")
-        if isinstance(e, httpx.HTTPStatusError):
-            print(f"Response body: {e.response.text}")
         return {
-            'content': f"Error: {str(e)}",
-            'error': True,
-            'model': model  # Keep original model on error
+            "content": f"Error: {str(e)}",
+            "error": True,
+            "model": model,
         }
 
 
 async def query_models_parallel(
     models: List[str],
-    messages: List[Dict[str, str]]
+    messages: List[Dict[str, str]],
+    *,
+    concurrency: int,
+    default_timeout: float,
+    timeout_overrides: Optional[Dict[str, float]] = None,
 ) -> Dict[str, Optional[Dict[str, Any]]]:
     """
     Query multiple models in parallel.
@@ -80,11 +139,14 @@ async def query_models_parallel(
     """
     import asyncio
 
-    # Create tasks for all models
-    tasks = [query_model(model, messages) for model in models]
+    timeout_overrides = timeout_overrides or {}
+    semaphore = asyncio.Semaphore(concurrency)
 
-    # Wait for all to complete
+    async def run(model: str) -> Optional[Dict[str, Any]]:
+        model_timeout = timeout_overrides.get(model, default_timeout)
+        async with semaphore:
+            return await query_model(model, messages, timeout=model_timeout)
+
+    tasks = [run(model) for model in models]
     responses = await asyncio.gather(*tasks)
-
-    # Map models to their responses
     return {model: response for model, response in zip(models, responses)}


### PR DESCRIPTION
## Summary
- add configurable stage-level concurrency and timeout defaults with per-councilor overrides
- apply semaphores to stage 1 and 2 dispatch to honor concurrency limits
- add rate-limit backoff and JSON-parse retry handling for OpenRouter requests

## Testing
- python -m compileall backend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4cdf180c83309d12edd5433fb3be)